### PR TITLE
Catch CalledProcessError on logged_call

### DIFF
--- a/git_svn_clone_externals.py
+++ b/git_svn_clone_externals.py
@@ -59,10 +59,14 @@ def logged_call(func, log=logger.debug):
         cwd = os.getcwd()
         command = " ".join(args)
         log("{cwd}$ {color}{command}{end_color}".format(**locals()))
-        res = func(args, **kwargs)
-        if res and func is subprocess.call:
-            color = col.RED
-            logger.error("{cwd}$ {color}{command}{end_color}".format(**locals()))
+        try:
+            res = func(args, **kwargs)
+        except subprocess.CalledProcessError as e:
+            res = e.returncode
+        finally:
+            if res and func is subprocess.call:
+                color = col.RED
+                logger.error("{cwd}$ {color}{command}{end_color}".format(**locals()))
         return res
     return _logged
 


### PR DESCRIPTION
Just add a try/catch in order to hide the python call stack on errors, in case `git-svn-xxx` called from outside. Not sure this is the best way to do it though... ;-)
